### PR TITLE
#5 Fix incorrect composer type (`project` => `library`)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "lukaswhite/php-feed-writer",
     "description": "A PHP library for writing feeds; e.g. RSS",
-    "type": "project",
+    "type": "library",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
Further info on https://github.com/lukaswhite/php-feed-writer/issues/5